### PR TITLE
Add busybox package for tftp client in system image

### DIFF
--- a/OSImage/POS_Image-Graphical6/config.xml
+++ b/OSImage/POS_Image-Graphical6/config.xml
@@ -87,6 +87,7 @@
         <package name="kexec-tools"/>
         <package name="plymouth"/>
         <package name="wpa_supplicant"/>
+        <package name="busybox"/>               <!-- this is needed if tftp is used for background image downloading -->
 
         <!-- packages specific for Graphical image -->
         <package name="patterns-sle-gnome-basic"/>

--- a/OSImage/POS_Image-JeOS6/config.xml
+++ b/OSImage/POS_Image-JeOS6/config.xml
@@ -87,6 +87,7 @@
         <package name="kexec-tools"/>
         <package name="plymouth"/>
         <package name="wpa_supplicant"/>
+        <package name="busybox"/>               <!-- this is needed if tftp is used for background image downloading -->
     </packages>
     <packages type="bootstrap">
         <package name="udev"/>


### PR DESCRIPTION
- background image download feature can be configured to use tftp
  for image download. For this to work we need a tftp client.
  Busybox provides one.