### PR TITLE
add missing software/products section which is required since 15 SP1

### DIFF
--- a/AutoYaST/SLES-12-SPn-to-SLES-15-SP2/autoyast.xml
+++ b/AutoYaST/SLES-12-SPn-to-SLES-15-SP2/autoyast.xml
@@ -70,7 +70,16 @@
     <modified config:type="boolean">true</modified>
     <remove_old config:type="boolean">false</remove_old>
   </backup>
-   <scripts>
+  <software>
+    <image/>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <patterns/>
+    <products config:type="list">
+      <listentry>SLES</listentry>
+    </products>
+  </software>
+  <scripts>
     <init-scripts config:type="list">
       $SNIPPET('spacewalk/minion_script')
 <!-- when client is traditional registered, please use this snippet


### PR DESCRIPTION
Since SLE15 SP1 the software/products section in an autoyast profile is required to tell the unified installer media which product should be updated.