### PR TITLE
Update to support arm and rpi enablement

### DIFF
--- a/OSImage/POS_Image-Graphical7/config.sh
+++ b/OSImage/POS_Image-Graphical7/config.sh
@@ -109,8 +109,10 @@ chkconfig firewalld on
 sed -Ei"" "s/#?GRUB_TERMINAL=.+$/GRUB_TERMINAL=gfxterm/g" /etc/default/grub
 sed -Ei"" "s/#?GRUB_GFXMODE=.+$/GRUB_GFXMODE=auto/g" /etc/default/grub
 
-# On UEFI machines use linuxefi entries
-echo 'GRUB_USE_LINUXEFI="true"' >> /etc/default/grub
+# On x86 UEFI machines use linuxefi entries
+if [[ "$(uname -m)" =~ i.86|x86_64 ]];then
+    echo 'GRUB_USE_LINUXEFI="true"' >> /etc/default/grub
+fi
 
 # Systemd controls the console font now
 echo FONT="$CONSOLE_FONT" >> /etc/vconsole.conf

--- a/OSImage/POS_Image-Graphical7/root/etc/systemd/system/install-local-bootloader.service
+++ b/OSImage/POS_Image-Graphical7/root/etc/systemd/system/install-local-bootloader.service
@@ -1,14 +1,19 @@
 [Unit]
 Description=Install bootloader for local boot
 
-# only if not configured yet
-ConditionPathExists=!/boot/grub2/grub.cfg
+# Saltboot installs the generic initrd downloaded from the Branch Server.
+# This service creates an initrd optimized for this machine (dracut --host-only).
+#
+# Execute the service if any of these files is missing:
+ConditionPathExists=|!/boot/grub2/grub.cfg
+ConditionPathExists=|!/var/lib/misc/bootloader_updated
 
 [Service]
 Type=oneshot
 ExecStartPre=/bin/bash -c 'if [ -e /sys/firmware/efi ]; then sed -i -e "s|^LOADER_TYPE=.*|LOADER_TYPE=\\"grub2-efi\\"|" /etc/sysconfig/bootloader; fi'
 ExecStartPre=/bin/bash -c 'if [ ! -e /sys/firmware/efi ]; then sed -i -e "s|^LOADER_TYPE=.*|LOADER_TYPE=\\"grub2\\"|" /etc/sysconfig/bootloader; fi'
 ExecStart=/bin/bash -c 'pbl --install ; dracut -f ; pbl --config '
+ExecStartPost=touch /var/lib/misc/bootloader_updated
 
 [Install]
 WantedBy=multi-user.target

--- a/OSImage/POS_Image-JeOS7/config.sh
+++ b/OSImage/POS_Image-JeOS7/config.sh
@@ -109,8 +109,10 @@ chkconfig firewalld on
 sed -Ei"" "s/#?GRUB_TERMINAL=.+$/GRUB_TERMINAL=gfxterm/g" /etc/default/grub
 sed -Ei"" "s/#?GRUB_GFXMODE=.+$/GRUB_GFXMODE=auto/g" /etc/default/grub
 
-# On UEFI machines use linuxefi entries
-echo 'GRUB_USE_LINUXEFI="true"' >> /etc/default/grub
+# On x86 UEFI machines use linuxefi entries
+if [[ "$(uname -m)" =~ i.86|x86_64 ]];then
+    echo 'GRUB_USE_LINUXEFI="true"' >> /etc/default/grub
+fi
 
 # Systemd controls the console font now
 echo FONT="$CONSOLE_FONT" >> /etc/vconsole.conf

--- a/OSImage/POS_Image-JeOS7/root/etc/systemd/system/install-local-bootloader.service
+++ b/OSImage/POS_Image-JeOS7/root/etc/systemd/system/install-local-bootloader.service
@@ -1,14 +1,19 @@
 [Unit]
 Description=Install bootloader for local boot
 
-# only if not configured yet
-ConditionPathExists=!/boot/grub2/grub.cfg
+# Saltboot installs the generic initrd downloaded from the Branch Server.
+# This service creates an initrd optimized for this machine (dracut --host-only).
+#
+# Execute the service if any of these files is missing:
+ConditionPathExists=|!/boot/grub2/grub.cfg
+ConditionPathExists=|!/var/lib/misc/bootloader_updated
 
 [Service]
 Type=oneshot
 ExecStartPre=/bin/bash -c 'if [ -e /sys/firmware/efi ]; then sed -i -e "s|^LOADER_TYPE=.*|LOADER_TYPE=\\"grub2-efi\\"|" /etc/sysconfig/bootloader; fi'
 ExecStartPre=/bin/bash -c 'if [ ! -e /sys/firmware/efi ]; then sed -i -e "s|^LOADER_TYPE=.*|LOADER_TYPE=\\"grub2\\"|" /etc/sysconfig/bootloader; fi'
 ExecStart=/bin/bash -c 'pbl --install ; dracut -f ; pbl --config '
+ExecStartPost=touch /var/lib/misc/bootloader_updated
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Use linuxefi only on x86
- Update install-local-bootloader.service for recent saltboot