### PR TITLE
Disable compressed build, install dmidecode

### DIFF
--- a/OSImage/POS_Image-Graphical7/config.xml
+++ b/OSImage/POS_Image-Graphical7/config.xml
@@ -18,7 +18,8 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"></type>
+        <!-- add luks="password" attribute below in order to generate encrypted image -->
+        <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="false"></type>
     </preferences>
 
     <packages type="image">
@@ -69,6 +70,7 @@
         <package name="mdadm"/>
         <package name="kernel-firmware"/>
         <package name="kexec-tools"/>
+        <package name="dmidecode"/>
 
         <!-- uncomment here to enable wireless boot
         <package name="dracut-wireless"/>

--- a/OSImage/POS_Image-JeOS7/config.xml
+++ b/OSImage/POS_Image-JeOS7/config.xml
@@ -18,8 +18,8 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <!-- add luks="password" in order to generate encrypted image -->
-        <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"></type>
+        <!-- add luks="password" attribute below in order to generate encrypted image -->
+        <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="false"></type>
     </preferences>
 
     <packages type="image">
@@ -67,6 +67,7 @@
 	<package name="salt-minion"/>
 
 	<package name="dracut-saltboot"/>
+        <package name="dmidecode"/>
         <package name="mdadm"/>
         <package name="kernel-firmware"/>
         <package name="kexec-tools"/>


### PR DESCRIPTION
- saltboot dracut module is missing correct dependencies for compressed images, disable them until new module is released