### PR TITLE
Use salt bundle by default in graphical 7 image

### DIFF
--- a/OSImage/POS_Image-Graphical7/config.xml
+++ b/OSImage/POS_Image-Graphical7/config.xml
@@ -64,7 +64,7 @@
         -->
 
         <package name="kernel-default"/>
-	<package name="salt-minion"/>
+	<package name="venv-salt-minion"/>
 
 	<package name="dracut-saltboot"/>
         <package name="mdadm"/>


### PR DESCRIPTION
PR #33 missed `config.xml` update for Graphical7 and it remained using salt-minion by default. This PR fixes that.