### PR TITLE
Master

### DIFF
--- a/AutoYaST/SLES-12-SPn-to-SLES-15-SP5/README.md
+++ b/AutoYaST/SLES-12-SPn-to-SLES-15-SP5/README.md
@@ -1,0 +1,17 @@
+This autoyast file has been used to upgrade from SLES12SP5 to SLES15SP5.
+The SLES12 system has only the mandatory repositories (modules) activated.
+
+Please do not change the kernel option according to the SUMA documentation.
+Disabling the self update feature in combination with self_update=0 pt.options=self_update and using a distribution based on GM (first official release) media DVD, will delete the installation rather then upgrading it.
+
+The autoupgrade option requires by default an registration server, however a SUMA server does not provided this expected functionality. Therefore the registration has to be turned off in the automation process. 
+
+If the environment requires an HTTPS secure connection rather then HTTP for the repositories URL. The booted OS witch performs the upgrade needs to have the CA of the SUMA server imported before contacting the SUMA server.
+This is done in the pre-script section.
+
+Starting with SLES15SP5 there is no python2 module available anymore, only python3 is offered via a dedicated supported modules.
+This needs to be consider during the upgrade. 
+
+It is possible to removed orphan packages during the upgrade, this can be done in the software section of the autoyast file during the upgrade.
+Another solution is to list the Non Compliant packages e.g via the WEB UI and delete these after the system has been upgraded and show up as a SLES15SP system.
+

--- a/AutoYaST/SLES-12-SPn-to-SLES-15-SP5/autoyast.xml
+++ b/AutoYaST/SLES-12-SPn-to-SLES-15-SP5/autoyast.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns"
+         xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+  $SNIPPET('spacewalk/sles_no_signature_checks')
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <ask_on_error config:type="boolean">true</ask_on_error>
+        <media_url>http://$redhat_management_server/ks/dist/child/sle-product-sles15-sp5-updates-x86_64/$distrotree</media_url>
+        <name>SLE-Product-SLES15-SP5-Updates for x86_64</name>
+        <product>SUSE Linux Enterprise Server 15 SP5 x86_64</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <ask_on_error config:type="boolean">true</ask_on_error>
+        <media_url>http://$redhat_management_server/ks/dist/child/sle-manager-tools15-pool-x86_64-sp5/$distrotree</media_url>
+        <name>SLE-Manager-Tools15-Pool for x86_64 SP5</name>
+        <product>SUSE Manager Tools 15 x86_64</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <ask_on_error config:type="boolean">true</ask_on_error>
+        <media_url>http://$redhat_management_server/ks/dist/child/sle-manager-tools15-updates-x86_64-sp5/$distrotree</media_url>
+        <name>SLE-Manager-Tools15-Updates for x86_64 SP5</name>
+        <product>SUSE Manager Tools 15 x86_64</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <ask_on_error config:type="boolean">true</ask_on_error>
+        <media_url>http://$redhat_management_server/ks/dist/child/sle-module-basesystem15-sp5-pool-x86_64/$distrotree</media_url>
+        <name>SLE-Module-Basesystem15-SP5-Pool for x86_64</name>
+        <product>Basesystem Module 15 SP5 x86_64</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <ask_on_error config:type="boolean">true</ask_on_error>
+        <media_url>http://$redhat_management_server/ks/dist/child/sle-module-basesystem15-sp5-updates-x86_64/$distrotree</media_url>
+        <name>SLE-Module-Basesystem15-SP5-Updates for x86_64</name>
+        <product>Basesystem Module 15 SP5 x86_64</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <ask_on_error config:type="boolean">true</ask_on_error>
+        <media_url>http://$redhat_management_server/ks/dist/child/sle-module-server-applications15-sp5-pool-x86_64/$distrotree</media_url>
+        <name>SLE-Module-Server-Applications15-SP5-Pool for x86_64</name>
+        <product>Server Applications Module 15 SP5 x86_64</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <ask_on_error config:type="boolean">true</ask_on_error>
+        <media_url>http://$redhat_management_server/ks/dist/child/sle-module-server-applications15-sp5-updates-x86_64/$distrotree</media_url>
+        <name>SLE-Module-Server-Applications15-SP5-Updates for x86_64</name>
+        <product>Server Applications Module 15 SP5 x86_64</product>
+        <product_dir>/</product_dir>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <upgrade>
+    <stop_on_solver_conflict config:type="boolean">true</stop_on_solver_conflict>
+  </upgrade>
+  <suse_register>
+    <do_registration config:type="boolean">false</do_registration>
+  </suse_register>
+  <backup>
+    <sysconfig config:type="boolean">true</sysconfig>
+    <modified config:type="boolean">true</modified>
+    <remove_old config:type="boolean">false</remove_old>
+  </backup>
+  <software>
+    <products config:type="list">
+      <product>SLES</product>
+    </products>
+  </software>
+  <scripts>
+<!-- This script is designed to ensure the certificate is present for any 'https' repositories -->
+    <pre-scripts config:type="list">
+       <script>
+         <rerun config:type="boolean">false</rerun>
+           <debug config:type="boolean">false</debug>
+           <feedback config:type="boolean">false</feedback>
+           <filename>01_import_cert</filename>
+           <interpreter>shell</interpreter>
+           <location/>
+           <notification>Importing SUMA CA certificate</notification>
+           <source><![CDATA[
+/usr/bin/wget -nv -r -nd --no-check-certificate https://$redhat_management_server/pub/RHN-ORG-TRUSTED-SSL-CERT
+mv RHN-ORG-TRUSTED-SSL-CERT /etc/pki/trust/anchors/
+/usr/sbin/update-ca-certificates
+     ]]></source>
+       </script>
+    </pre-scripts>
+    <init-scripts config:type="list">
+      $SNIPPET('spacewalk/minion_script')
+<!-- when client is traditional registered, please replace the above snippet value with
+      'spacewalk/sles_register_script'
+-->
+    </init-scripts>
+  </scripts>
+</profile>


### PR DESCRIPTION
The existent autoyast file from sles12sn-to-sles15sp2 has been used as a base and has been modified to run with sles15sp5. 
It is important to mention that the self_update feature should not be turned off, as mentioned in the SUMA documentation. An additional registration section is also required to successfully automate the upgrade. 