### PR TITLE
Adapt SLE12 templates to be buildable by kiwi-ng

### DIFF
--- a/OSImage/POS_Image-Graphical6/POS_Image-Graphical6.changes
+++ b/OSImage/POS_Image-Graphical6/POS_Image-Graphical6.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 13 10:10:26 UTC 2024 - Ondrej Holecek <oholecek@suse.com>
+
+- fix hostname package name
+- remove unused image types and conform with kiwi-ng
+
+-------------------------------------------------------------------
 Mon Jul 29 11:32:55 UTC 2024 - Ondrej Holecek <oholecek@suse.com>
 
 - Enable compressed builds

--- a/OSImage/POS_Image-Graphical6/config.xml
+++ b/OSImage/POS_Image-Graphical6/config.xml
@@ -18,9 +18,7 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type boot="saltboot/suse-SLES12" bootloader="grub2" checkprebuilt="true" compressed="true" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"></type>
-        <type boot="isoboot/suse-SLES12" image="iso"></type>
-        <type boot="oemboot/suse-SLES12" filesystem="ext3" image="oem" installiso="true"></type>
+        <type boot="saltboot/suse-SLES12" checkprebuilt="true" compressed="true" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"></type>
     </preferences>
     <!--    CUSTOM REPOSITORY -->
     <repository type="rpm-dir">
@@ -71,7 +69,7 @@
         <package name="python-base"/>
         <package name="rsync"/>
         <!-- packages for saltboot and SUSE Manager -->
-        <package name="hostname"/>
+        <package name="net-tools"/>
         <package name="venv-salt-minion"/>
         <!-- or
         <package name="salt-minion"/>

--- a/OSImage/POS_Image-JeOS6/POS_Image-JeOS6.changes
+++ b/OSImage/POS_Image-JeOS6/POS_Image-JeOS6.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 13 10:10:26 UTC 2024 - Ondrej Holecek <oholecek@suse.com>
+
+- fix hostname package name
+- remove unused image types and conform with kiwi-ng
+
+-------------------------------------------------------------------
 Mon Jul 29 11:33:39 UTC 2024 - Ondrej Holecek <oholecek@suse.com>
 
 - Enable compressed builds

--- a/OSImage/POS_Image-JeOS6/config.xml
+++ b/OSImage/POS_Image-JeOS6/config.xml
@@ -18,9 +18,7 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type boot="saltboot/suse-SLES12" bootloader="grub2" checkprebuilt="true" compressed="true" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"></type>
-        <type boot="isoboot/suse-SLES12" image="iso"></type>
-        <type boot="oemboot/suse-SLES12" filesystem="ext3" image="oem" installiso="true"></type>
+        <type boot="saltboot/suse-SLES12" checkprebuilt="true" compressed="true" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"></type>
     </preferences>
     <!--    CUSTOM REPOSITORY -->
     <repository type="rpm-dir">
@@ -71,7 +69,7 @@
         <package name="python-base"/>
         <package name="rsync"/>
         <!-- packages for saltboot and SUSE Manager -->
-        <package name="hostname"/>
+        <package name="net-tools"/>
         <package name="venv-salt-minion"/>
         <!-- or
         <package name="salt-minion"/>


### PR DESCRIPTION
This PR
- fixes a bug in hostname package naming introduced in 981b7b0c8
- removes unused extra image types and make template conformant with kiwi-ng

Build tested with kiwi-ng and kiwi-legacy