### PR TITLE
Fix Keytable and workaround for network-legacy

### DIFF
--- a/OSImage/POS_Image-Graphical7/POS_Image-Graphical7.changes
+++ b/OSImage/POS_Image-Graphical7/POS_Image-Graphical7.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan  9 14:22:50 UTC 2025 - Ondrej Holecek <oholecek@suse.com>
+
+- Fix keytable and gnome-icon-theme (bsc#1233607)
+- Add saltboot install check and missing procps dependnecy
+
+-------------------------------------------------------------------
 Mon Jul 29 11:35:50 UTC 2024 - Ondrej Holecek <oholecek@suse.com>
 
 - Enable compressed builds

--- a/OSImage/POS_Image-Graphical7/config.xml
+++ b/OSImage/POS_Image-Graphical7/config.xml
@@ -13,7 +13,7 @@
         <bootloader-theme>SLE</bootloader-theme>
 
         <locale>en_US</locale>
-        <keytable>us.map.gz</keytable>
+        <keytable>us</keytable>
         <timezone>Europe/Berlin</timezone>
         <hwclock>utc</hwclock>
 
@@ -29,6 +29,7 @@
         <package name="chrony"/>
         <package name="curl"/>
         <package name="dracut"/>
+        <package name="procps"/> <!-- needed for dracut network-legacy -->
         <package name="fipscheck"/>
         <package name="group(mail)"/> <!-- needed by useradd bsc#1061838-->
         <package name="group(wheel)"/>
@@ -110,7 +111,6 @@
         <package name="nautilus"/>
 
         <!-- Themes and branding -->
-        <package name="gnome-icon-theme"/>
         <package name="gnome-menus-branding-SLE"/>
         <package name="gtk2-metatheme-adwaita"/>
         <package name="gtk3-metatheme-adwaita"/>

--- a/OSImage/POS_Image-Graphical7/root/etc/dracut.conf.d/90-saltboot.conf
+++ b/OSImage/POS_Image-Graphical7/root/etc/dracut.conf.d/90-saltboot.conf
@@ -1,0 +1,1 @@
+add_dracutmodules+=" saltboot "

--- a/OSImage/POS_Image-JeOS7/POS_Image-JeOS7.changes
+++ b/OSImage/POS_Image-JeOS7/POS_Image-JeOS7.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan  9 14:22:50 UTC 2025 - Ondrej Holecek <oholecek@suse.com>
+
+- Fix keytable (bsc#1233607)
+- Add saltboot install check and missing procps dependnecy
+
+-------------------------------------------------------------------
 Mon Jul 29 11:35:00 UTC 2024 - Ondrej Holecek <oholecek@suse.com>
 
 - Enable compressed builds

--- a/OSImage/POS_Image-JeOS7/config.xml
+++ b/OSImage/POS_Image-JeOS7/config.xml
@@ -13,7 +13,7 @@
         <bootloader-theme>SLE</bootloader-theme>
 
         <locale>en_US</locale>
-        <keytable>us.map.gz</keytable>
+        <keytable>us</keytable>
         <timezone>Europe/Berlin</timezone>
         <hwclock>utc</hwclock>
 
@@ -28,6 +28,7 @@
         <package name="acl"/>
         <package name="chrony"/>
         <package name="curl"/>
+        <package name="procps"/> <!-- needed for dracut network-legacy -->
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="group(mail)"/> <!-- needed by useradd bsc#1061838-->

--- a/OSImage/POS_Image-JeOS7/root/etc/dracut.conf.d/90-saltboot.conf
+++ b/OSImage/POS_Image-JeOS7/root/etc/dracut.conf.d/90-saltboot.conf
@@ -1,0 +1,1 @@
+add_dracutmodules+=" saltboot "


### PR DESCRIPTION
Additionally to $TOPIC, this PR adds
- saltboot force install
- install procps (pgrep)